### PR TITLE
add exit code for error handler

### DIFF
--- a/build/source/driver/multi_driver.f90
+++ b/build/source/driver/multi_driver.f90
@@ -1241,7 +1241,7 @@ contains
  do iFreq = 1,nFreq
   nc_err = nf90_close(ncid(iFreq))
  end do
- stop
+ stop 9
  end subroutine handle_err
 
  ! **************************************************************************************************


### PR DESCRIPTION
to be recognized by Shell where the model is called from when the simulation failed.
